### PR TITLE
feat(mfa): #WB-1608, send full sms sending report to sms mod proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ compileTestJava {
 dependencies {
   compileOnly "io.vertx:vertx-core:$vertxVersion"
   compile "fr.wseduc:web-utils:$webutilsVersion"
+  compile "org.entcore:common:$entCoreVersion"
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ modowner=fr.wseduc
 modname=mod-sms-proxy
 
 # Your module version
-version=1.0-SNAPSHOT
+version=1.1-SNAPSHOT
 
 # The test timeout in seconds
 testtimeout=300
@@ -30,4 +30,6 @@ toolsVersion=2.0.0-final
 junitVersion=4.10
 
 webutilsVersion=2.0.0
+
+entCoreVersion=4.9-dev-produit-SNAPSHOT
 

--- a/src/main/java/fr/wseduc/smsproxy/providers/SmsProvider.java
+++ b/src/main/java/fr/wseduc/smsproxy/providers/SmsProvider.java
@@ -21,6 +21,7 @@ import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.sms.SmsSendingReport;
 
 
 public abstract class SmsProvider {
@@ -54,13 +55,13 @@ public abstract class SmsProvider {
 	 * @param message : Original message
 	 * @param error : Error message
 	 * @param e : Exception thrown
-	 * @param data : Additional data
+	 * @param data : Additional data from the provider
 	 */
-	protected void sendError(Message<JsonObject> message, String error, Exception e, JsonObject data){
+	protected void sendError(Message<JsonObject> message, String error, Exception e, SmsSendingReport data){
 		logger.error(error + " -> " + data, e);
-	    JsonObject json = new JsonObject().put("status", "error")
+	    final JsonObject json = new JsonObject().put("status", "error")
 	    		.put("message", error)
-	    		.put("data", data);
+	    		.put("data", JsonObject.mapFrom(data));
 	    message.reply(json);
 	}
 
@@ -75,12 +76,15 @@ public abstract class SmsProvider {
 	}
 
 	/**
-	 * Error management method, sends back a message containing the errer details on the bus.
+	 * Error management method, sends back a message containing the error details on the bus.
 	 * @param message : Original message
-	 * @param error : Error message
+	 * @param report : Additional data from the provider
 	 */
-	protected void sendError(Message<JsonObject> message, String error) {
-		sendError(message, error, null);
+	protected void replyOk(Message<JsonObject> message, final SmsSendingReport report){
+		final JsonObject json = new JsonObject().put("status", "ok")
+				.put("data", JsonObject.mapFrom(report));
+		message.reply(json);
 	}
+
 
 }

--- a/src/main/java/fr/wseduc/smsproxy/providers/ovh/OVHSmsSendingReport.java
+++ b/src/main/java/fr/wseduc/smsproxy/providers/ovh/OVHSmsSendingReport.java
@@ -1,0 +1,45 @@
+package fr.wseduc.smsproxy.providers.ovh;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A structure describing all information about quota informations as described in OVH documentation.
+ *
+ * {@see https://api.ovh.com/console/#/sms/%7BserviceName%7D/users/%7Blogin%7D/jobs~POST}
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OVHSmsSendingReport {
+    private final long[] ids;
+    private final String[] invalidReceivers;
+    private final double totalCreditsRemoved;
+    private final String[] validReceivers;
+
+    @JsonCreator
+    public OVHSmsSendingReport(@JsonProperty("ids") final long[] ids,
+                               @JsonProperty("invalidReceivers") final String[] invalidReceivers,
+                               @JsonProperty("totalCreditsRemoved") final double totalCreditsRemoved,
+                               @JsonProperty("validReceivers") final String[] validReceivers) {
+        this.ids = ids;
+        this.invalidReceivers = invalidReceivers;
+        this.totalCreditsRemoved = totalCreditsRemoved;
+        this.validReceivers = validReceivers;
+    }
+
+    public long[] getIds() {
+        return ids;
+    }
+
+    public String[] getInvalidReceivers() {
+        return invalidReceivers;
+    }
+
+    public double getTotalCreditsRemoved() {
+        return totalCreditsRemoved;
+    }
+
+    public String[] getValidReceivers() {
+        return validReceivers;
+    }
+}


### PR DESCRIPTION
Afin de pouvoir suivre la bonne réception des SMS et de qualifier les problèmes de réception, la solution suivante a été mise en place :
- récupérer les ids des sms envoyés par le provider
- enregistrer ces ids dans les tables d'événements