### PR TITLE
[ODE] feat(sms-monitoring): Record the durations of interactions with OVH to send SMS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ compileTestJava {
 dependencies {
   compileOnly "io.vertx:vertx-core:$vertxVersion"
   compile "fr.wseduc:web-utils:$webutilsVersion"
+  compile "io.vertx:vertx-micrometer-metrics:$vertxVersion"
+  compile "io.micrometer:micrometer-registry-prometheus:$micrometerPrometheusVersion"
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,4 +30,5 @@ toolsVersion=2.0.0-final
 junitVersion=4.10
 
 webutilsVersion=2.10-SNAPSHOT
+micrometerPrometheusVersion=1.1.0
 

--- a/src/main/java/fr/wseduc/smsproxy/Sms.java
+++ b/src/main/java/fr/wseduc/smsproxy/Sms.java
@@ -18,6 +18,7 @@ package fr.wseduc.smsproxy;
 
 import java.util.ServiceLoader;
 
+import fr.wseduc.smsproxy.providers.metrics.SmsMetricsRecorderFactory;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonObject;
@@ -39,6 +40,7 @@ public class Sms extends BusModBase implements Handler<Message<JsonObject>> {
 		vertx.eventBus().consumer(config.getString("address", "entcore.sms"), this);
 		implementations = ServiceLoader.load(SmsProvider.class);
 		providersList = config.getJsonObject("providers");
+		SmsMetricsRecorderFactory.init(vertx, config);
 
 		if(providersList == null){
 			logger.error("providers.list.empty");

--- a/src/main/java/fr/wseduc/smsproxy/providers/metrics/SmsMetricsRecorder.java
+++ b/src/main/java/fr/wseduc/smsproxy/providers/metrics/SmsMetricsRecorder.java
@@ -1,0 +1,23 @@
+package fr.wseduc.smsproxy.providers.metrics;
+
+/**
+ * Records metrics specific to OVH SMS-sending service.
+ */
+public interface SmsMetricsRecorder {
+
+    /** Record the fact that an interaction with SMS service to send SMS has been done and has taken {@code duration}
+     * milliseconds.
+     * N.B. : Call this method even if the interaction has failed.
+     * */
+    void onSmsSent(final long duration);
+
+    /**
+     * Mock implementation used when no metrics options are defined.
+     */
+    class NoopSmsMetricsRecorder implements SmsMetricsRecorder {
+        @Override
+        public void onSmsSent(final long delay) {
+            // Do nothing in this implementation
+        }
+    }
+}

--- a/src/main/java/fr/wseduc/smsproxy/providers/metrics/SmsMetricsRecorderFactory.java
+++ b/src/main/java/fr/wseduc/smsproxy/providers/metrics/SmsMetricsRecorderFactory.java
@@ -1,0 +1,45 @@
+package fr.wseduc.smsproxy.providers.metrics;
+
+import fr.wseduc.smsproxy.providers.metrics.impl.MicrometerSmsMetricsRecorder;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.metrics.MetricsOptions;
+
+public class SmsMetricsRecorderFactory {
+    private static JsonObject config;
+    private static MetricsOptions metricsOptions;
+    private static SmsMetricsRecorder smsMetricsRecorder;
+    private SmsMetricsRecorderFactory(){}
+    public static void init(final Vertx vertx, final JsonObject config) {
+        SmsMetricsRecorderFactory.config = config;
+        final String metricsOptionsName = "metricsOptions";
+        if(config.getJsonObject(metricsOptionsName) == null) {
+            final String metricsOptions = (String) vertx.sharedData().getLocalMap("server").get(metricsOptionsName);
+            if(metricsOptions == null){
+                SmsMetricsRecorderFactory.metricsOptions = new MetricsOptions().setEnabled(false);
+            }else{
+                SmsMetricsRecorderFactory.metricsOptions = new MetricsOptions(new JsonObject(metricsOptions));
+            }
+        } else {
+            metricsOptions = new MetricsOptions(config.getJsonObject(metricsOptionsName));
+        }
+    }
+
+    /**
+     * @return The backend to record metrics. If metricsOptions is defined in the configuration then the backend used
+     * is MicroMeter. Otherwise a dummy registrar is returned and it collects nothing.
+     */
+    public static SmsMetricsRecorder getInstance() {
+        if(smsMetricsRecorder == null) {
+            if(metricsOptions == null) {
+                throw new IllegalStateException("sms.metricsrecorder.factory.not.set");
+            }
+            if(metricsOptions.isEnabled()) {
+                smsMetricsRecorder = new MicrometerSmsMetricsRecorder(MicrometerSmsMetricsRecorder.Configuration.fromJson(config));
+            } else {
+                smsMetricsRecorder = new SmsMetricsRecorder.NoopSmsMetricsRecorder();
+            }
+        }
+        return smsMetricsRecorder;
+    }
+}

--- a/src/main/java/fr/wseduc/smsproxy/providers/metrics/impl/MicrometerSmsMetricsRecorder.java
+++ b/src/main/java/fr/wseduc/smsproxy/providers/metrics/impl/MicrometerSmsMetricsRecorder.java
@@ -1,0 +1,74 @@
+package fr.wseduc.smsproxy.providers.metrics.impl;
+
+import fr.wseduc.smsproxy.providers.metrics.SmsMetricsRecorder;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.micrometer.backends.BackendRegistries;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class MicrometerSmsMetricsRecorder implements SmsMetricsRecorder {
+    private final Timer smsSendingTimes;
+
+    public MicrometerSmsMetricsRecorder(final Configuration configuration) {
+        final MeterRegistry registry = BackendRegistries.getDefaultNow();
+        if(registry == null) {
+            throw new IllegalStateException("micrometer.registries.empty");
+        }
+        final Timer.Builder smsSendingTimesBuilder = Timer.builder("sms.sending.time")
+                .description("time to send SMS");
+        if(configuration.sla.isEmpty()) {
+            smsSendingTimesBuilder
+                    .publishPercentileHistogram()
+                    .maximumExpectedValue(Duration.ofSeconds(2L));
+        } else {
+            smsSendingTimesBuilder.sla(configuration.sla.toArray(new Duration[0]));
+        }
+        smsSendingTimes = smsSendingTimesBuilder.register(registry);
+    }
+
+    @Override
+    public void onSmsSent(final long duration) {
+        smsSendingTimes.record(duration, TimeUnit.MILLISECONDS);
+    }
+
+    public static class Configuration {
+        private final List<Duration> sla;
+
+        public Configuration(final List<Duration> sla) {
+            this.sla = sla;
+        }
+
+        /**
+         * Create the recorder's configuration from the attribute {@code metrics} of the parameter {@code conf} (or send
+         * back a default configuration if conf is {@code null} or if it has no {@code metrics} field.
+         * @param conf an object with the following keys :
+         *          <ul>
+         *               <li>sla, an ordered list of longs whose values are the bucket boundaries for the exported Timer which records the time
+         *               spent waiting for a response from OVH</li>
+         *           </ul>
+         * @return The built configuration
+         */
+        public static Configuration fromJson(final JsonObject conf) {
+            final List<Duration> sla;
+            if(conf == null || !conf.containsKey("metrics")) {
+                sla = Collections.emptyList();
+            } else {
+                final JsonObject metrics = conf.getJsonObject("metrics");
+                sla = metrics.getJsonArray("sla", new JsonArray()).stream()
+                    .mapToLong(long.class::cast)
+                    .sorted()
+                    .mapToObj(Duration::ofMillis)
+                    .collect(Collectors.toList());
+            }
+            return new Configuration(sla);
+        }
+    }
+}


### PR DESCRIPTION
# Description

Permet au module mod-sms-sender d'exposer ses propres métriques d'intéraction avec OVH pour l'envoi des SMS.
 Cela nous permettra de créer des dashboards de suivi plus pointus et de voir facilement si une erreur en prod vient de lenteurs d'interaction avec OVH.

De plus, les logs d'erreur commencent maintenant par `[OVH][sendSms]` afin de les uniformiser avec le reste des logs et de faciliter la recherche lors de l'exploitation

## Fixes

WB-1696

## Type of change

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Tests

1. Connexion en local avec tom.mate
2. Tentative d'accès à /admin
3. Vérification qu'un sms a bien été envoyé
4. Aller à l'url http://localhost:9090/metrics
5. Constater que `sms_sending_time_seconds_count` a été incrémenté et que les buckets `sms_sending_time_seconds_bucket` ont été mis à jour


# Reminder

-  Je dois mettre à jour le reminder du 2FA pour modifier la conf metricsOptions

- [x] All done ! :smiley: