### PR TITLE
Sinch sms provider

### DIFF
--- a/build-noDocker.sh
+++ b/build-noDocker.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+if [ -z ${USER_UID:+x} ]
+then
+  export USER_UID=1000
+  export GROUP_GID=1000
+fi
+
+clean () {
+  gradle gradle clean
+}
+
+buildGradle () {
+  gradle shadowJar install publishToMavenLocal
+}
+
+publish () {
+  if [ -e "?/.gradle" ] && [ ! -e "?/.gradle/gradle.properties" ]
+  then
+    echo "odeUsername=$NEXUS_ODE_USERNAME" > "?/.gradle/gradle.properties"
+    echo "odePassword=$NEXUS_ODE_PASSWORD" >> "?/.gradle/gradle.properties"
+    echo "sonatypeUsername=$NEXUS_SONATYPE_USERNAME" >> "?/.gradle/gradle.properties"
+    echo "sonatypePassword=$NEXUS_SONATYPE_PASSWORD" >> "?/.gradle/gradle.properties"
+  fi
+  gradle publish
+}
+
+for param in "$@"
+do
+  case $param in
+    clean)
+      clean
+      ;;
+    buildGradle)
+      buildGradle
+      ;;
+    install)
+      buildGradle
+      ;;
+    publish)
+      publish
+      ;;
+    *)
+      echo "Invalid argument : $param"
+  esac
+  if [ ! $? -eq 0 ]; then
+    exit 1
+  fi
+done
+

--- a/src/main/java/fr/wseduc/smsproxy/providers/sinch/SinchSmsProvider.java
+++ b/src/main/java/fr/wseduc/smsproxy/providers/sinch/SinchSmsProvider.java
@@ -28,10 +28,15 @@ public class SinchSmsProvider extends SmsProvider {
      * Api endpoint
      */
     private String apiEndpoint;
+    /**
+     * Client reference
+     */
+    private String clientReference;
     @Override
     public void initProvider(Vertx vertx, JsonObject conf) {
         this.apiToken = conf.getString("apiToken", "");
         this.apiEndpoint = conf.getString("baseUrl", "") + "/" + conf.getString("servicePlanId", "") + "/batches";
+        this.clientReference = conf.getString("clientReference", "");
         this.httpClient = vertx.createHttpClient();
     }
 
@@ -66,7 +71,7 @@ public class SinchSmsProvider extends SmsProvider {
         String body = new JsonObject()
                 .put("to", parameters.getJsonArray("receivers"))
                 .put("body", parameters.getValue("message"))
-                .put("client_reference", "marius testing")
+                .put("client_reference", clientReference)
                 .toString();
         Buffer bodyBuffer = Buffer.buffer();
         bodyBuffer.appendString(body, "UTF-8");
@@ -96,9 +101,7 @@ public class SinchSmsProvider extends SmsProvider {
             if (response == null) {
                 sendError(message, ErrorCodes.CALL_ERROR, null);
             } else {
-                response.bodyHandler(body -> {
-                    message.reply(new JsonObject(body.toString()));
-                });
+                response.bodyHandler(body -> message.reply(new JsonObject(body.toString())));
             }
         };
 

--- a/src/main/java/fr/wseduc/smsproxy/providers/sinch/SinchSmsProvider.java
+++ b/src/main/java/fr/wseduc/smsproxy/providers/sinch/SinchSmsProvider.java
@@ -90,7 +90,7 @@ public class SinchSmsProvider extends SmsProvider {
         return new SmsSendingReport(
                 new String[]{sinchSmsSendingReport.getId()},
                 new String[]{},
-                sinchSmsSendingReport.getTo());
+                new String[]{});
     }
 
     @Override

--- a/src/main/java/fr/wseduc/smsproxy/providers/sinch/SinchSmsProvider.java
+++ b/src/main/java/fr/wseduc/smsproxy/providers/sinch/SinchSmsProvider.java
@@ -17,7 +17,7 @@ import io.vertx.core.json.JsonObject;
 public class SinchSmsProvider extends SmsProvider {
 
     /**
-     * Http Client
+     * Http Client used to call Sinch endpoints
      */
     private HttpClient httpClient;
     /**
@@ -25,11 +25,11 @@ public class SinchSmsProvider extends SmsProvider {
      */
     private String apiToken;
     /**
-     * Api endpoint
+     * Sinch api endpoint for sms batch
      */
     private String apiEndpoint;
     /**
-     * Client reference
+     * Client reference, not mandatory to call Sinch api, but can be useful to transmit parametrized information about the caller
      */
     private String clientReference;
     @Override

--- a/src/main/java/fr/wseduc/smsproxy/providers/sinch/SinchSmsSendingReport.java
+++ b/src/main/java/fr/wseduc/smsproxy/providers/sinch/SinchSmsSendingReport.java
@@ -1,0 +1,43 @@
+package fr.wseduc.smsproxy.providers.sinch;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Report model based on Sinch API response after sending sms.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SinchSmsSendingReport {
+    private final String id;
+
+    private final String[] to;
+
+    private final boolean cancel;
+    private final String clientReference;
+
+    public SinchSmsSendingReport(@JsonProperty("id") String id,
+                                 @JsonProperty("to") String[] to,
+                                 @JsonProperty("cancel") boolean cancel,
+                                 @JsonProperty("client_reference") String clientReference) {
+        this.id = id;
+        this.to = to;
+        this.cancel = cancel;
+        this.clientReference = clientReference;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String[] getTo() {
+        return to;
+    }
+
+    public boolean isCancel() {
+        return cancel;
+    }
+
+    public String getClientReference() {
+        return clientReference;
+    }
+}

--- a/src/main/java/fr/wseduc/smsproxy/providers/sinch/SinchSmsSendingReport.java
+++ b/src/main/java/fr/wseduc/smsproxy/providers/sinch/SinchSmsSendingReport.java
@@ -11,17 +11,13 @@ public class SinchSmsSendingReport {
     private final String id;
 
     private final String[] to;
-
-    private final boolean cancel;
     private final String clientReference;
 
     public SinchSmsSendingReport(@JsonProperty("id") String id,
                                  @JsonProperty("to") String[] to,
-                                 @JsonProperty("cancel") boolean cancel,
                                  @JsonProperty("client_reference") String clientReference) {
         this.id = id;
         this.to = to;
-        this.cancel = cancel;
         this.clientReference = clientReference;
     }
 
@@ -31,10 +27,6 @@ public class SinchSmsSendingReport {
 
     public String[] getTo() {
         return to;
-    }
-
-    public boolean isCancel() {
-        return cancel;
     }
 
     public String getClientReference() {

--- a/src/main/resources/META-INF/services/fr.wseduc.smsproxy.providers.SmsProvider
+++ b/src/main/resources/META-INF/services/fr.wseduc.smsproxy.providers.SmsProvider
@@ -1,1 +1,2 @@
 fr.wseduc.smsproxy.providers.ovh.OVHSmsProvider
+fr.wseduc.smsproxy.providers.sinch.SinchSmsProvider


### PR DESCRIPTION
Related issue : https://opendigitaleducation.atlassian.net/browse/WB-1790

This brings a first implementation of Sinch as Sms provider.

This requires the following update in the Springboard :

- Declaring a new provider in the list of providers in mod-sms-sender config :
```
"providers" : {
  "Sinch" : {
    "servicePlanId" : "",
    "apiToken" : "",
    "baseUrl": "",
    "clientReference": ""
  }
}
```

> Let's note that clientReference is not mandatory to call Sinch API, but can be useful to transmit parametrized information about the caller.

- Changing the provider to be used in the module config where the sms is required to be sent (e.g. entcore) :
```
"sharedConf" : {
  "smsProvider" : "Sinch"
}
```
Reminder has been updated with these config changes.