### PR TITLE
[EDIFICE] Ajout d'un préfixe au numéro des destinataires de SMS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
-gradle:
-  image: gradle:4.5-alpine
-  working_dir: /home/gradle/project
-  volumes:
-    - ./:/home/gradle/project
-    - ~/.m2:/home/gradle/.m2
-    - ~/.gradle:/home/gradle/.gradle
+version: "3"
+services:
+  gradle:
+    image: opendigitaleducation/gradle:4.5.1
+    working_dir: /home/gradle/project
+    volumes:
+      - ./:/home/gradle/project
+      - ~/.m2:/home/gradle/.m2
+      - ~/.gradle:/home/gradle/.gradle
 


### PR DESCRIPTION
# Description

2 tickets sont traités dans cette PR :

1. l'ajout d'un préfixe aux numéros des destinataires de SMS livrés par Sinch (sinon il y a une erreur d'envoi de la part de Sinch disant qu'il ne connaît pas le numéro)
2. le changement de l'image gradle pour pointer vers une image utilisable par les Mac M*