### PR TITLE
WB-2114 enriching sms with senderID and better exception handling

### DIFF
--- a/src/main/java/fr/wseduc/smsproxy/providers/sinch/SinchSmsProvider.java
+++ b/src/main/java/fr/wseduc/smsproxy/providers/sinch/SinchSmsProvider.java
@@ -55,7 +55,7 @@ public class SinchSmsProvider extends SmsProvider {
                 sendError(message, ErrorCodes.CALL_ERROR, null);
             } else if (response.statusCode() != 201) {
                 sendError(message, ErrorCodes.CALL_ERROR, null);
-                response.bodyHandler(body -> logger.error("[Sinch][sendSms] Error when calling sinch API : " + body.toString()));
+                response.bodyHandler(body -> logger.error("[Sinch][sendSms] Error with status code : " + response.statusCode() + " when calling sinch API : " + body.toString()));
             } else {
                 response.bodyHandler(body -> {
                     try {


### PR DESCRIPTION
Ticket lié : https://edifice-community.atlassian.net/browse/WB-2114

Ajout de l'identifiant de l'émetteur lors de l'envoi d'un sms.
* L'identifiant choisi doit être renseigné dans la configuration du springboard, et peut donc différer pour chaque plateforme
* Si aucun identifiant d'émetteur n'est spécifié dans la config, le sms est quand même envoyé avec le **Automatic Default Originator** géré par Sinch.