### PR TITLE
[EDIFICE] Register sms sending metrics for all SMS providers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,7 @@ then
   export GROUP_GID=1000
 fi
 
+
 clean () {
   docker-compose run --rm -u "$USER_UID:$GROUP_GID" gradle gradle clean
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ modowner=fr.wseduc
 modname=mod-sms-proxy
 
 # Your module version
-version=1.2-SNAPSHOT
+version=1.2-b2school-SNAPSHOT
 
 # The test timeout in seconds
 testtimeout=300

--- a/src/main/java/fr/wseduc/smsproxy/providers/metrics/SmsMetricsRecorder.java
+++ b/src/main/java/fr/wseduc/smsproxy/providers/metrics/SmsMetricsRecorder.java
@@ -11,12 +11,19 @@ public interface SmsMetricsRecorder {
      * */
     void onSmsSent(final long duration);
 
+    void onSmsFailure(final long duration);
+
     /**
      * Mock implementation used when no metrics options are defined.
      */
     class NoopSmsMetricsRecorder implements SmsMetricsRecorder {
         @Override
         public void onSmsSent(final long delay) {
+            // Do nothing in this implementation
+        }
+
+        @Override
+        public void onSmsFailure(final long duration) {
             // Do nothing in this implementation
         }
     }


### PR DESCRIPTION
# Description

Le but de cette PR est d'avoir des métriques sur les temps d'envoi indépendantes du fournisseur de SMS. Auparavant, seule l'implémentation pour le fournisseur OVH exposait ces métriques.

Le code mettant à jour ces métriques ont donc été déplacées de l'implémentation concrète des classes à la classe abstraite dont elle dérive `SmsProvider`.

De plus, le temps des appels qui terminent en erreur est désormais enregistré.

# Fix
WB-2128